### PR TITLE
Removing the Cyclomatic Complexity

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/StringUtil.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/StringUtil.java
@@ -82,27 +82,28 @@ public final class StringUtil {
         }
 
         int l = 1;
-        for (int curOffset = 0; curOffset < offsetInclusive; curOffset++) {
-            // if we end up outside the string, then the line is undefined
-            if (curOffset >= len) {
-                return -1;
-            }
+        int curOffset = 0;
+        boolean isPrevCharCr = false;
 
+        while (curOffset < offsetInclusive && curOffset < len) {
             char c = charSeq.charAt(curOffset);
+
             if (c == '\n') {
                 l++;
+                isPrevCharCr = false;
             } else if (c == '\r') {
-                if (curOffset + 1 < len && charSeq.charAt(curOffset + 1) == '\n') {
-                    if (curOffset == offsetInclusive - 1) {
-                        // the CR is assumed to be on the same line as the LF
-                        return l;
-                    }
-                    curOffset++; // SUPPRESS CHECKSTYLE jump to after the \n
+                if (isPrevCharCr) {
+                    l++;
                 }
-                l++;
+                isPrevCharCr = true;
+            } else {
+                isPrevCharCr = false;
             }
+
+            curOffset++;
         }
-        return l;
+
+        return curOffset < offsetInclusive ? -1 : l;
     }
 
     /**


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->
In this PR I am Fixing the Cyclomatic Complexity instance that occurs in the file StringUtil.java that is in the net.sourceforge.pmd.util package that exists within pmd-core 

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes 1
- I fixed this bad smell by reducing the number of nested if else statements and using different options of keeping track of the different branchs 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

