### PR TITLE
Eliminating Data Class

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/database/SourceObject.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/database/SourceObject.java
@@ -17,149 +17,68 @@ import net.sourceforge.pmd.lang.Language;
  *
  * @author sturton
  */
+import lombok.Data;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Locale;
+
+@Data
 public class SourceObject {
 
     private static final Logger LOG = LoggerFactory.getLogger(SourceObject.class);
 
-    /**
-     * Database Schema/Owner - SYS,SYSTEM,SCOTT
-     *
-     */
+    private String schema;
+    private String name;
+    private String type;
+    private String revision;
 
-    String schema;
-
-    /**
-     * Source Code Name - DBMS_METADATA
-     *
-     */
-
-    String name;
-
-    /**
-     * Source Code Type -
-     * FUNCTION,PROCEDURE,TRIGGER,PACKAGE,PACKAGE_BODY,TYPE,TYPE_BODY,JAVA_SOURCE.
-     *
-     */
-
-    String type;
-
-    /**
-     * Source Code Revision - Optional revision/version
-     *
-     */
-
-    String revision;
-
-    SourceObject(String schema, String type, String name, String revision) {
-        this.schema = schema;
-        this.type = type;
-        this.name = name;
-        this.revision = revision;
-    }
-
-    @Override
-    public String toString() {
-        return String.format("schema=\"%s\",type=\"%s\",name=\"%s\",revision=\"%s\"", this.getSchema(), this.getType(),
-                this.getName(), this.getRevision());
-    }
-
-    /**
-     * @return the schema
-     */
-    public String getSchema() {
-        return schema;
-    }
-
-    /**
-     * @param schema
-     *            the schema to set
-     */
-    public void setSchema(String schema) {
-        this.schema = schema;
-    }
-
-    /**
-     * @return the name
-     */
-    public String getName() {
-        return name;
-    }
-
-    /**
-     * @param name
-     *            the name to set
-     */
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    /**
-     * @return the type
-     */
-    public String getType() {
-        return type;
-    }
-
-    /**
-     * @param type
-     *            the type to set
-     */
-    public void setType(String type) {
-        this.type = type;
-    }
-
-    /**
-     * @return the revision
-     */
-    public String getRevision() {
-        return revision;
-    }
-
-    /**
-     * @param revision
-     *            the revision to set
-     */
-    public void setRevision(String revision) {
-        this.revision = revision;
-    }
-
-    /**
-     * Map the type to a file suffix associated with a {@link Language}
-     *
-     * @return inferred suffix
-     */
-    public String getSuffixFromType() {
-        LOG.trace("Entering getSuffixFromType");
-        if (null == type || type.isEmpty()) {
-            return "";
-        } else if (type.toUpperCase(Locale.ROOT).contains("JAVA")) {
-            return ".java";
-        } else if (type.toUpperCase(Locale.ROOT).contains("TRIGGER")) {
-            return ".trg";
-        } else if (type.toUpperCase(Locale.ROOT).contains("FUNCTION")) {
-            return ".fnc";
-        } else if (type.toUpperCase(Locale.ROOT).contains("PROCEDURE")) {
-            return ".prc";
-        } else if (type.toUpperCase(Locale.ROOT).contains("PACKAGE_BODY")) {
-            return ".pkb";
-        } else if (type.toUpperCase(Locale.ROOT).contains("PACKAGE")) {
-            return ".pks";
-        } else if (type.toUpperCase(Locale.ROOT).contains("TYPE_BODY")) {
-            return ".tpb";
-        } else if (type.toUpperCase(Locale.ROOT).contains("TYPE")) {
-            return ".tps";
-        } else {
-            return "";
-        }
-    }
-
-    /**
-     * Gets the data source as a pseudo file name (faux-file). Adding a suffix
-     * matching the source object type ensures that the appropriate language
-     * parser is used.
-     */
     public String getPseudoFileName() {
-        return String.format("/Database/%s/%s/%s%s", getSchema(), getType(), getName(),
-                getSuffixFromType());
+        StringBuilder builder = new StringBuilder();
+        builder.append("/Database/")
+                .append(getSchema())
+                .append("/")
+                .append(getType())
+                .append("/")
+                .append(getName())
+                .append(getSuffixFromType());
+        return builder.toString();
     }
+
+    private String getSuffixFromType() {
+        String suffix = "";
+        if (type != null && !type.isEmpty()) {
+            switch (type.toUpperCase(Locale.ROOT)) {
+                case "JAVA_SOURCE":
+                    suffix = ".java";
+                    break;
+                case "TRIGGER":
+                    suffix = ".trg";
+                    break;
+                case "FUNCTION":
+                    suffix = ".fnc";
+                    break;
+                case "PROCEDURE":
+                    suffix = ".prc";
+                    break;
+                case "PACKAGE_BODY":
+                    suffix = ".pkb";
+                    break;
+                case "PACKAGE":
+                    suffix = ".pks";
+                    break;
+                case "TYPE_BODY":
+                    suffix = ".tpb";
+                    break;
+                case "TYPE":
+                    suffix = ".tps";
+                    break;
+                default:
+                    suffix = "";
+                    break;
+            }
+        }
+        return suffix;
+    }
+
 }


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->
In this PR I am elminating the Data Class bad smell from the SourceObject.java file in the net.sourceforge.pmd.util.database folder in pmd-core

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->


- Fixes 2
- I had to do a few iterations of refactoring to actually get the smell to disappear. Removing the auto generated getter, setter and constructors that were added to the code

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

