### PR TITLE
Adding Fix For Fix Number 2

### DIFF
--- a/pmd-ant/src/main/java/net/sourceforge/pmd/ant/internal/Slf4jSimpleConfigurationForAnt.java
+++ b/pmd-ant/src/main/java/net/sourceforge/pmd/ant/internal/Slf4jSimpleConfigurationForAnt.java
@@ -118,7 +118,7 @@ public final class Slf4jSimpleConfigurationForAnt {
                     declaredField = XmlLogger.class.getDeclaredField("msgOutputLevel");
                 } else if (l instanceof RecorderEntry) {
                     declaredField = RecorderEntry.class.getDeclaredField("loglevel");
-                } else if ("org.gradle.api.internal.project.ant.AntLoggingAdapter".equals(l.getClass().getName())) {
+                } else if (l instanceof org.gradle.api.internal.project.ant.AntLoggingAdapter) {
                     return determineGradleLogLevel(project, l);
                 } else {
                     try {


### PR DESCRIPTION

(1) the reasons of the change

Trying to determine an objects type based on its class is dangerous 
(2) the refactoring operations performed to fix the change
Using the method InstanceOf to compare instead
(3) the impact of the change on quality (mentioning quality attributes that has been improved/unimproved).
This is fixing one of the 36  remaining bugs