### PR TITLE
Adding in fix number 3

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/PmdAnalysis.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/PmdAnalysis.java
@@ -389,7 +389,7 @@ public final class PmdAnalysis implements AutoCloseable {
             } catch (Exception e) {
                 reporter.errorEx("Exception while closing analysis listeners", e);
                 // todo better exception
-                throw new RuntimeException("Exception while closing analysis listeners", e);
+                
             }
         }
     }


### PR DESCRIPTION
(1)  the reasons of the change, 
When you have a throw or a break or a return in a finally statement it " block suppresses the propagation of any unhandled Throwable which was thrown in the try or catch block." 

(2) the refactoring operations performed to fix the change
For this I was reviewing the code and noticed that it essentially calls the exception twice but once with a throw so I belive the step to solve this is to remove the throw line all together 

(3) the impact of the change on quality (mentioning quality attributes that has been improved/unimproved).
This was a major bug so this would decrease the overall number of bugs from 35 to 34

